### PR TITLE
Implemented cloud shell policy, which overrides local policy

### DIFF
--- a/src/lib/watchtower-client.ts
+++ b/src/lib/watchtower-client.ts
@@ -32,7 +32,6 @@ export interface McpRule {
 
 export interface PolicyBundle {
   shell_rules: ShellRule[];
-  protected_paths: string[];
   mcp_rules: McpRule[];
   updated_at: string;
 }
@@ -246,21 +245,20 @@ export async function fetchPolicies(
   const p = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
   return {
     shell_rules: Array.isArray(p['shell_rules']) ? (p['shell_rules'] as ShellRule[]) : [],
-    protected_paths: Array.isArray(p['protected_paths']) ? (p['protected_paths'] as string[]) : [],
     mcp_rules: Array.isArray(p['mcp_rules']) ? (p['mcp_rules'] as McpRule[]) : [],
     updated_at: typeof p['updated_at'] === 'string' ? p['updated_at'] : new Date().toISOString(),
   };
 }
 
 /**
- * GET /api/settings/shell_policies — fetch shell policy rules.
- * Handles both array response and { rules: [] } response shapes.
+ * GET /api/policies/shell_sync — fetch shell policy rules for local runtime sync.
+ * Handles { items: [] } plus older array / { rules: [] } response shapes.
  */
 export async function fetchShellPolicies(
   apiKey: string,
   baseUrl: string
 ): Promise<ShellRule[]> {
-  const url = buildWatchtowerUrl(baseUrl, '/api/settings/shell_policies');
+  const url = buildWatchtowerUrl(baseUrl, '/api/policies/shell_sync');
   const { status, body } = await nodeRequest('GET', url, bearerHeaders(apiKey), null, 15_000);
 
   if (status < 200 || status >= 300) {
@@ -275,6 +273,9 @@ export async function fetchShellPolicies(
 
   if (raw && typeof raw === 'object') {
     const r = raw as Record<string, unknown>;
+    if (Array.isArray(r['items'])) {
+      return r['items'] as ShellRule[];
+    }
     if (Array.isArray(r['rules'])) {
       return r['rules'] as ShellRule[];
     }

--- a/src/plugin/cloud-policy-evaluator.ts
+++ b/src/plugin/cloud-policy-evaluator.ts
@@ -1,0 +1,50 @@
+import type { CloudPolicyCache } from './cloud-policy';
+
+export interface CloudRuleMatch {
+  action?: 'BLOCK' | 'WARN' | 'LOG';
+  severity?: string;
+  rule: string;
+  description?: string;
+}
+
+export function evaluateCloudShellRule(command: string, cloudPolicy: CloudPolicyCache): CloudRuleMatch | null {
+  for (const rule of cloudPolicy.shell_rules) {
+    try {
+      const re = new RegExp(rule.pattern, 'i');
+      if (re.test(command)) {
+        return {
+          action: rule.action,
+          severity: rule.severity,
+          rule: rule.pattern,
+          description: rule.description,
+        };
+      }
+    } catch {
+      // Ignore invalid regex patterns from cache.
+    }
+  }
+
+  return null;
+}
+
+export function evaluateCloudMcpRule(toolName: string, cloudPolicy: CloudPolicyCache): CloudRuleMatch | null {
+  for (const rule of cloudPolicy.mcp_rules) {
+    try {
+      const matches =
+        toolName.startsWith(rule.tool_pattern) ||
+        new RegExp(rule.tool_pattern, 'i').test(toolName);
+      if (matches) {
+        return {
+          action: rule.action,
+          severity: rule.severity,
+          rule: rule.tool_pattern,
+          description: rule.description,
+        };
+      }
+    } catch {
+      // Ignore invalid regex patterns from cache.
+    }
+  }
+
+  return null;
+}

--- a/src/plugin/cloud-policy.ts
+++ b/src/plugin/cloud-policy.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'fs';
+
+import { getDataPath } from '../core/data-dir';
+import type { SecurityPolicy } from '../types';
+import type { McpRule, ShellRule } from '../lib/watchtower-client';
+
+export interface CloudPolicyCache {
+  shell_rules: ShellRule[];
+  mcp_rules: McpRule[];
+  updated_at?: string;
+}
+
+export interface RuntimePolicyResolution {
+  policy: SecurityPolicy;
+  source: 'local' | 'cloud';
+  cloudPolicy: CloudPolicyCache | null;
+}
+
+const CLOUD_AUTHORITATIVE_POLICY: SecurityPolicy = {
+  defaultAction: 'ALLOW',
+  modules: {},
+};
+
+export function loadCloudPolicyCache(): CloudPolicyCache | null {
+  try {
+    const raw = readFileSync(getDataPath('policies.json'), 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    const record = parsed as Record<string, unknown>;
+    return {
+      shell_rules: Array.isArray(record['shell_rules']) ? (record['shell_rules'] as ShellRule[]) : [],
+      mcp_rules: Array.isArray(record['mcp_rules']) ? (record['mcp_rules'] as McpRule[]) : [],
+      updated_at: typeof record['updated_at'] === 'string' ? record['updated_at'] : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function resolveRuntimePolicy(localPolicy: SecurityPolicy): RuntimePolicyResolution {
+  const cloudPolicy = loadCloudPolicyCache();
+  if (!cloudPolicy) {
+    return {
+      policy: localPolicy,
+      source: 'local',
+      cloudPolicy: null,
+    };
+  }
+
+  return {
+    policy: CLOUD_AUTHORITATIVE_POLICY,
+    source: 'cloud',
+    cloudPolicy,
+  };
+}
+
+export function getCloudAuthoritativeRuntimePolicy(): RuntimePolicyResolution | null {
+  const cloudPolicy = loadCloudPolicyCache();
+  if (!cloudPolicy) {
+    return null;
+  }
+
+  return {
+    policy: CLOUD_AUTHORITATIVE_POLICY,
+    source: 'cloud',
+    cloudPolicy,
+  };
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -19,6 +19,7 @@ import { Interceptor } from '../core/Interceptor';
 import { PolicyStore } from '../storage/PolicyStore';
 import { logger } from '../core/Logger';
 import { createToolCallHook } from './tool-interceptor';
+import { getCloudAuthoritativeRuntimePolicy } from './cloud-policy';
 import { channelContextStore } from './ChannelContextStore';
 import { initNotifier, sendApprovalNotification, type FallbackChannel } from './oob-notifier';
 import { createApproveCommand, createDenyCommand } from './approval-commands';
@@ -179,13 +180,20 @@ export default {
     logger.info('Reins plugin loading...');
 
     try {
-      const policy = PolicyStore.loadSync();
+      const runtimePolicy =
+        getCloudAuthoritativeRuntimePolicy() ||
+        {
+          policy: PolicyStore.loadSync(),
+          source: 'local' as const,
+          cloudPolicy: null,
+        };
       logger.info('Security policy loaded', {
-        defaultAction: policy.defaultAction,
-        moduleCount: Object.keys(policy.modules).length,
+        source: runtimePolicy.source,
+        defaultAction: runtimePolicy.policy.defaultAction,
+        moduleCount: Object.keys(runtimePolicy.policy.modules).length,
       });
 
-      const interceptor = new Interceptor(policy);
+      const interceptor = new Interceptor(runtimePolicy.policy);
 
       // -------------------------------------------------------------------
       // OOB notifier: initialise with runtime send functions + gateway config

--- a/src/plugin/tool-interceptor.ts
+++ b/src/plugin/tool-interceptor.ts
@@ -11,6 +11,11 @@ import { MemoryRiskForecaster, MemoryRiskAssessment } from '../core/MemoryRiskFo
 import { trustRateLimiter } from '../core/TrustRateLimiter';
 import { InterventionMetadata } from '../types';
 import { BrowserSessionStore } from '../storage/BrowserSessionStore';
+import { loadCloudPolicyCache } from './cloud-policy';
+import {
+  evaluateCloudMcpRule,
+  evaluateCloudShellRule,
+} from './cloud-policy-evaluator';
 import {
   classifyDestructiveAction,
   DestructiveClassification,
@@ -120,6 +125,106 @@ export function createToolCallHook(
 
     let params = event.params;
     let shouldReturnParams = false;
+    const cloudPolicy = loadCloudPolicyCache();
+
+    if (
+      cloudPolicy &&
+      moduleName === 'Shell' &&
+      ['bash', 'exec'].includes(methodName)
+    ) {
+      const command = typeof params.command === 'string' ? params.command : '';
+      const matchedRule = evaluateCloudShellRule(command, cloudPolicy);
+
+      if (matchedRule?.action === 'BLOCK') {
+        const reason =
+          `Reins Cloud policy blocked shell command. ` +
+          `${matchedRule.description || 'No description provided.'} ` +
+          `[rule: ${matchedRule.rule}; severity: ${matchedRule.severity || 'unknown'}]`;
+        await DecisionLog.append({
+          timestamp: new Date().toISOString(),
+          module: moduleName,
+          method: methodName,
+          args: [params],
+          decision: 'BLOCKED',
+          decisionTime: 0,
+          reason,
+          eventType: 'tool_blocked',
+          tool: toolName,
+        });
+        return { block: true, blockReason: reason };
+      }
+
+      if (matchedRule?.action === 'WARN') {
+        logger.warn('Reins Cloud shell rule matched with WARN action', {
+          toolName,
+          command,
+          rule: matchedRule.rule,
+          severity: matchedRule.severity,
+        });
+      }
+
+      await DecisionLog.append({
+        timestamp: new Date().toISOString(),
+        module: moduleName,
+        method: methodName,
+        args: [params],
+        decision: 'ALLOWED',
+        decisionTime: 0,
+        reason: matchedRule
+          ? 'allowed by Reins Cloud shell policy cache'
+          : 'allowed by Reins Cloud shell policy cache (no matching block rule)',
+        eventType: 'tool_executed',
+        tool: toolName,
+      });
+      return shouldReturnParams ? { params } : {};
+    }
+
+    // Checks if rule matches one of the MCP tool names (if not, matchedRule will be null and execution continues)
+    if (cloudPolicy) {
+      const matchedRule = evaluateCloudMcpRule(toolName, cloudPolicy);
+
+      if (matchedRule?.action === 'BLOCK') {
+        const reason =
+          `Reins Cloud policy blocked MCP tool. ` +
+          `${matchedRule.description || 'No description provided.'} ` +
+          `[rule: ${matchedRule.rule}; severity: ${matchedRule.severity || 'unknown'}]`;
+        await DecisionLog.append({
+          timestamp: new Date().toISOString(),
+          module: moduleName,
+          method: methodName,
+          args: [params],
+          decision: 'BLOCKED',
+          decisionTime: 0,
+          reason,
+          eventType: 'tool_blocked',
+          tool: toolName,
+        });
+        return { block: true, blockReason: reason };
+      }
+
+      if (matchedRule?.action === 'WARN') {
+        logger.warn('Reins Cloud MCP rule matched with WARN action', {
+          toolName,
+          rule: matchedRule.rule,
+          severity: matchedRule.severity,
+        });
+      }
+
+      if (matchedRule) {
+        await DecisionLog.append({
+          timestamp: new Date().toISOString(),
+          module: moduleName,
+          method: methodName,
+          args: [params],
+          decision: 'ALLOWED',
+          decisionTime: 0,
+          reason: 'allowed by Reins Cloud MCP policy cache',
+          eventType: 'tool_executed',
+          tool: toolName,
+        });
+        return shouldReturnParams ? { params } : {};
+      }
+    }
 
     // Persistent browser-session management.
     if (moduleName === 'Browser') {

--- a/test/policy.test.mjs
+++ b/test/policy.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
-import { mkdtempSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 
 const openclawHome = mkdtempSync(path.join(os.tmpdir(), 'reins-policy-tests-'));
 mkdirSync(openclawHome, { recursive: true });
@@ -14,6 +14,7 @@ process.env.REINS_DESTRUCTIVE_GATING = 'off';
 const require = createRequire(import.meta.url);
 const { Interceptor } = require('../dist/core/Interceptor.js');
 const { createToolCallHook } = require('../dist/plugin/tool-interceptor.js');
+const { resolveRuntimePolicy } = require('../dist/plugin/cloud-policy.js');
 
 // Temp dirs used as stand-ins for real paths — no real directories assumed
 const allowedDir = mkdtempSync(path.join(os.tmpdir(), 'reins-allowed-'));
@@ -23,6 +24,16 @@ const allowedFile = path.join(allowedDir, 'output.txt');
 const outsideFile = path.join(outsideDir, 'other.txt');
 const secretsFile = path.join(secretsDir, 'keys.json');
 const nestedFile = path.join(allowedDir, 'subdir', 'readme.md');
+
+function writeCloudPolicies(payload) {
+  const reinsDir = path.join(openclawHome, 'reins');
+  mkdirSync(reinsDir, { recursive: true });
+  writeFileSync(path.join(reinsDir, 'policies.json'), JSON.stringify(payload, null, 2));
+}
+
+function clearCloudPolicies() {
+  rmSync(path.join(openclawHome, 'reins', 'policies.json'), { force: true });
+}
 
 // ---------------------------------------------------------------------------
 // defaultAction
@@ -56,6 +67,60 @@ test('defaultAction ALLOW passes unmapped tools', async () => {
   );
 
   assert.notEqual(result.block, true);
+});
+
+test('cloud policy becomes the authoritative runtime policy when policies.json exists', () => {
+  writeCloudPolicies({
+    shell_rules: [],
+    mcp_rules: [],
+    updated_at: new Date().toISOString(),
+  });
+
+  const localPolicy = {
+    defaultAction: 'DENY',
+    modules: {
+      Shell: {
+        exec: { action: 'DENY', description: 'local deny should be ignored' },
+      },
+    },
+  };
+
+  const runtime = resolveRuntimePolicy(localPolicy);
+  assert.equal(runtime.source, 'cloud');
+  assert.equal(runtime.policy.defaultAction, 'ALLOW');
+  assert.deepEqual(runtime.policy.modules, {});
+
+  clearCloudPolicies();
+});
+
+test('cloud shell cache overrides local shell policy in OpenClaw runtime', async () => {
+  writeCloudPolicies({
+    shell_rules: [],
+    mcp_rules: [],
+    updated_at: new Date().toISOString(),
+  });
+
+  const interceptor = new Interceptor(
+    {
+      defaultAction: 'DENY',
+      modules: {
+        Shell: {
+          exec: { action: 'DENY', description: 'local deny should be ignored' },
+        },
+      },
+    },
+    false
+  );
+  const hook = createToolCallHook(interceptor);
+
+  const result = await hook(
+    { toolName: 'exec', params: { command: 'echo avocado' } },
+    { toolName: 'exec', sessionKey: 'policy:cloud-shell-authoritative' }
+  );
+
+  assert.notEqual(result.block, true);
+
+  clearCloudPolicies();
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Reins Cloud is now the main policy source for OpenClaw runtime shell and MCP enforcement, instead of relying on the inbuilt reins policy. The policies.json file, which comes from Reins Cloud, is the source of policy unless it doesn't exist, in which case the inbuilt policy is used. protected_paths was removed from Reins Cloud interfacing because that functionality does not exist in Reins Cloud.