### PR TITLE
Feature/claude enterprise bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "bin": {
     "reins": "./dist/cli/index.js"
   },
-  "scripts": {
+    "scripts": {
     "build": "tsc",
     "test": "npm run build && node --test test/**/*.test.mjs",
     "lint": "eslint src --ext .ts",
@@ -23,8 +23,7 @@
     "ai-agents",
     "openclaw",
     "human-in-the-loop",
-    "runtime-interception",
-    "winston": "^3.11.0"
+    "runtime-interception"
   ],
   "author": "Kevin Wu <kevin@usepegasi.com>",
   "license": "Apache-2.0",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reins",
   "description": "Runtime security for AI agents. Blocks destructive actions before execution, routes high-risk operations through human approval, and maintains an immutable audit trail. Covers OWASP MCP Top 10, ASI Top 10, and Agentic Skills Top 10.",
-  "version": "0.0.23",
+  "version": "0.0.27",
   "author": {
     "name": "Pegasi"
   },

--- a/plugin/bin/reins-post-hook
+++ b/plugin/bin/reins-post-hook
@@ -1,6 +1,6 @@
-#!/bin/sh
-# Reins PostToolUse hook — wrapper for the globally installed @pegasi/reins package.
-# Requires: npm install -g @pegasi/reins
+#!/usr/bin/env sh
+# Reins PostToolUse hook — wrapper for the globally installed @pegasi-ai/reins package.
+# Requires: npm install -g @pegasi-ai/reins
 set -e
 
 REINS_ROOT="$(npm root -g 2>/dev/null)/@pegasi/reins"

--- a/plugin/bin/reins-pre-hook
+++ b/plugin/bin/reins-pre-hook
@@ -1,6 +1,6 @@
-#!/bin/sh
-# Reins PreToolUse hook — wrapper for the globally installed @pegasi/reins package.
-# Requires: npm install -g @pegasi/reins
+#!/usr/bin/env sh
+# Reins PreToolUse hook — wrapper for the globally installed @pegasi-ai/reins package.
+# Requires: npm install -g @pegasi-ai/reins
 set -e
 
 REINS_ROOT="$(npm root -g 2>/dev/null)/@pegasi/reins"

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,18 +1,10 @@
 {
   "hooks": {
     "PreToolUse": [
-      { "matcher": "Bash",      "hooks": [{ "type": "command", "command": "reins-pre-hook" }] },
-      { "matcher": "Edit",      "hooks": [{ "type": "command", "command": "reins-pre-hook" }] },
-      { "matcher": "MultiEdit", "hooks": [{ "type": "command", "command": "reins-pre-hook" }] },
-      { "matcher": "Write",     "hooks": [{ "type": "command", "command": "reins-pre-hook" }] },
-      { "matcher": "",          "hooks": [{ "type": "command", "command": "reins-pre-hook" }] }
+      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/bin/reins-pre-hook", "args": [] }] }
     ],
     "PostToolUse": [
-      { "matcher": "Bash",      "hooks": [{ "type": "command", "command": "reins-post-hook" }] },
-      { "matcher": "Edit",      "hooks": [{ "type": "command", "command": "reins-post-hook" }] },
-      { "matcher": "MultiEdit", "hooks": [{ "type": "command", "command": "reins-post-hook" }] },
-      { "matcher": "Write",     "hooks": [{ "type": "command", "command": "reins-post-hook" }] },
-      { "matcher": "",          "hooks": [{ "type": "command", "command": "reins-post-hook" }] }
+      { "matcher": "", "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/bin/reins-post-hook", "args": [] }] }
     ]
   }
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -21,8 +21,19 @@ import { getProtectedModules } from '../plugin/tool-interceptor';
 import { syncToolShieldDefaults } from '../toolshield/sync';
 import { runSetupScan } from './scan';
 import { installWatchtowerSchedule, supportsScheduledScans } from './scheduler';
-import { resolveWatchtowerCredentials, saveWatchtowerSettings, DEFAULT_WATCHTOWER_BASE_URL } from '../storage/WatchtowerConfig';
-import { signupCli, validateApiKey, fetchPolicies, fetchShellPolicies } from '../lib/watchtower-client';
+import {
+  resolveWatchtowerBootstrap,
+  resolveWatchtowerCredentials,
+  saveWatchtowerSettings,
+  DEFAULT_WATCHTOWER_BASE_URL,
+} from '../storage/WatchtowerConfig';
+import {
+  redeemReinsBootstrap,
+  signupCli,
+  validateApiKey,
+  fetchPolicies,
+  fetchShellPolicies,
+} from '../lib/watchtower-client';
 import { installClaudeCodeHooks } from '../lib/hook-installer';
 
 type SecurityLevel = 'permissive' | 'balanced' | 'strict' | 'custom';
@@ -262,6 +273,48 @@ async function maybeOfferWatchtowerSchedule(): Promise<string | null> {
   return result.descriptor;
 }
 
+async function connectWithEnterpriseBootstrap(jsonMode: boolean, warnings: string[]): Promise<boolean> {
+  const bootstrap = await resolveWatchtowerBootstrap();
+  if (!bootstrap) {
+    return false;
+  }
+
+  try {
+    if (!jsonMode) {
+      console.log(chalk.bold('Step 7: Redeeming enterprise bootstrap...'));
+      console.log(chalk.dim('  Using managed Reins Cloud bootstrap token.'));
+    }
+
+    const result = await redeemReinsBootstrap(bootstrap.token, bootstrap.baseUrl);
+    await saveWatchtowerSettings({
+      apiKey: result.api_key,
+      baseUrl: bootstrap.baseUrl,
+      dashboardUrl: result.dashboard_url,
+      org_id: result.organization?.id,
+      connectedAt: new Date().toISOString(),
+    });
+
+    if (!jsonMode) {
+      console.log(chalk.green('✅ Connected to Reins Cloud via enterprise bootstrap'));
+      if (result.organization) {
+        console.log(chalk.dim(`  Organization: ${result.organization.name} (${result.organization.id})`));
+      }
+      console.log(chalk.dim(`  Dashboard: ${result.dashboard_url ?? bootstrap.baseUrl}`));
+      console.log('');
+    }
+
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warnings.push(`Reins Cloud enterprise bootstrap failed: ${message}`);
+    if (!jsonMode) {
+      console.log(chalk.yellow(`⚠️  Enterprise bootstrap failed: ${message}`));
+      console.log('');
+    }
+    return false;
+  }
+}
+
 export async function initWizard(options: InitWizardOptions = {}): Promise<InitSuccessOutput> {
   const nonInteractive = options.nonInteractive === true;
   const jsonMode = options.json === true;
@@ -487,7 +540,9 @@ export async function initWizard(options: InitWizardOptions = {}): Promise<InitS
   }
 
   // Step 7: Watchtower API key + Claude Code hooks (interactive only)
-  if (!nonInteractive) {
+  const enterpriseConnected = await connectWithEnterpriseBootstrap(jsonMode, warnings);
+
+  if (!enterpriseConnected && !nonInteractive) {
     const { connectWatchtower } = await inquirer.prompt([{
       type: 'confirm',
       name: 'connectWatchtower',
@@ -546,6 +601,26 @@ export async function initWizard(options: InitWizardOptions = {}): Promise<InitS
     }
 
     // Install Claude Code hooks
+    if (!jsonMode) {
+      console.log(chalk.bold('Step 7b: Installing Claude Code hooks...'));
+    }
+    try {
+      const hookResult = await installClaudeCodeHooks();
+      if (!jsonMode) {
+        if (hookResult.alreadyInstalled) {
+          console.log(chalk.green('✅ Claude Code hooks already installed'));
+        } else {
+          console.log(chalk.green(`✅ Claude Code hooks installed at ${hookResult.path}`));
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      warnings.push(`Claude Code hook installation failed: ${msg}`);
+      if (!jsonMode) {
+        console.log(chalk.yellow(`⚠️  Hook installation failed: ${msg}`));
+      }
+    }
+  } else {
     if (!jsonMode) {
       console.log(chalk.bold('Step 7b: Installing Claude Code hooks...'));
     }

--- a/src/lib/watchtower-client.ts
+++ b/src/lib/watchtower-client.ts
@@ -42,6 +42,15 @@ export interface SignupCliResult {
   message: string;
 }
 
+export interface RedeemBootstrapResult {
+  api_key: string;
+  dashboard_url?: string;
+  organization?: {
+    id: string;
+    name: string;
+  };
+}
+
 /**
  * POST /api/auth/signup-cli — creates or signs in a user by email and returns
  * a fresh API key + magic-link dashboard URL. No prior key needed.
@@ -74,6 +83,52 @@ export async function signupCli(
   }
 
   return { api_key, dashboard_url, message };
+}
+
+/**
+ * POST /api/auth/reins-bootstrap/redeem — redeems an explicit org bootstrap token
+ * for a fresh API key. Used by enterprise-managed installs.
+ */
+export async function redeemReinsBootstrap(
+  token: string,
+  baseUrl: string
+): Promise<RedeemBootstrapResult> {
+  const url = buildWatchtowerUrl(baseUrl, '/api/auth/reins-bootstrap/redeem');
+  const { status, body } = await nodeRequest(
+    'POST',
+    url,
+    {},
+    JSON.stringify({ token }),
+    15_000
+  );
+
+  if (status < 200 || status >= 300) {
+    throw new Error(`Reins bootstrap redemption failed: HTTP ${status} — ${body.trim()}`);
+  }
+
+  const raw = JSON.parse(body) as unknown;
+  const p = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+  const api_key = typeof p['api_key'] === 'string' ? p['api_key'] : '';
+  if (!api_key) {
+    throw new Error('Reins bootstrap redemption returned no API key.');
+  }
+
+  const organization =
+    p['organization'] && typeof p['organization'] === 'object'
+      ? (p['organization'] as Record<string, unknown>)
+      : null;
+
+  return {
+    api_key,
+    dashboard_url: typeof p['dashboard_url'] === 'string' ? p['dashboard_url'] : undefined,
+    organization:
+      organization && typeof organization['id'] === 'string' && typeof organization['name'] === 'string'
+        ? {
+            id: organization['id'],
+            name: organization['name'],
+          }
+        : undefined,
+  };
 }
 
 export interface RunStartPayload {

--- a/src/lib/watchtower-client.ts
+++ b/src/lib/watchtower-client.ts
@@ -32,7 +32,6 @@ export interface McpRule {
 
 export interface PolicyBundle {
   shell_rules: ShellRule[];
-  protected_paths: string[];
   mcp_rules: McpRule[];
   updated_at: string;
 }
@@ -246,21 +245,20 @@ export async function fetchPolicies(
   const p = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
   return {
     shell_rules: Array.isArray(p['shell_rules']) ? (p['shell_rules'] as ShellRule[]) : [],
-    protected_paths: Array.isArray(p['protected_paths']) ? (p['protected_paths'] as string[]) : [],
     mcp_rules: Array.isArray(p['mcp_rules']) ? (p['mcp_rules'] as McpRule[]) : [],
     updated_at: typeof p['updated_at'] === 'string' ? p['updated_at'] : new Date().toISOString(),
   };
 }
 
 /**
- * GET /api/settings/shell_policies — fetch shell policy rules.
- * Handles both array response and { rules: [] } response shapes.
+ * GET /api/policies/shell_sync — fetch shell policy rules for local runtime sync.
+ * Handles { items: [] } plus older array / { rules: [] } response shapes.
  */
 export async function fetchShellPolicies(
   apiKey: string,
   baseUrl: string
 ): Promise<ShellRule[]> {
-  const url = buildWatchtowerUrl(baseUrl, '/api/settings/shell_policies');
+  const url = buildWatchtowerUrl(baseUrl, '/api/policies/shell_sync');
   const { status, body } = await nodeRequest('GET', url, bearerHeaders(apiKey), null, 15_000);
 
   if (status < 200 || status >= 300) {
@@ -275,6 +273,9 @@ export async function fetchShellPolicies(
 
   if (raw && typeof raw === 'object') {
     const r = raw as Record<string, unknown>;
+    if (Array.isArray(r['items'])) {
+      return r['items'] as ShellRule[];
+    }
     if (Array.isArray(r['rules'])) {
       return r['rules'] as ShellRule[];
     }

--- a/src/plugin/cloud-policy-evaluator.ts
+++ b/src/plugin/cloud-policy-evaluator.ts
@@ -1,0 +1,50 @@
+import type { CloudPolicyCache } from './cloud-policy';
+
+export interface CloudRuleMatch {
+  action?: 'BLOCK' | 'WARN' | 'LOG';
+  severity?: string;
+  rule: string;
+  description?: string;
+}
+
+export function evaluateCloudShellRule(command: string, cloudPolicy: CloudPolicyCache): CloudRuleMatch | null {
+  for (const rule of cloudPolicy.shell_rules) {
+    try {
+      const re = new RegExp(rule.pattern, 'i');
+      if (re.test(command)) {
+        return {
+          action: rule.action,
+          severity: rule.severity,
+          rule: rule.pattern,
+          description: rule.description,
+        };
+      }
+    } catch {
+      // Ignore invalid regex patterns from cache.
+    }
+  }
+
+  return null;
+}
+
+export function evaluateCloudMcpRule(toolName: string, cloudPolicy: CloudPolicyCache): CloudRuleMatch | null {
+  for (const rule of cloudPolicy.mcp_rules) {
+    try {
+      const matches =
+        toolName.startsWith(rule.tool_pattern) ||
+        new RegExp(rule.tool_pattern, 'i').test(toolName);
+      if (matches) {
+        return {
+          action: rule.action,
+          severity: rule.severity,
+          rule: rule.tool_pattern,
+          description: rule.description,
+        };
+      }
+    } catch {
+      // Ignore invalid regex patterns from cache.
+    }
+  }
+
+  return null;
+}

--- a/src/plugin/cloud-policy.ts
+++ b/src/plugin/cloud-policy.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'fs';
+
+import { getDataPath } from '../core/data-dir';
+import type { SecurityPolicy } from '../types';
+import type { McpRule, ShellRule } from '../lib/watchtower-client';
+
+export interface CloudPolicyCache {
+  shell_rules: ShellRule[];
+  mcp_rules: McpRule[];
+  updated_at?: string;
+}
+
+export interface RuntimePolicyResolution {
+  policy: SecurityPolicy;
+  source: 'local' | 'cloud';
+  cloudPolicy: CloudPolicyCache | null;
+}
+
+const CLOUD_AUTHORITATIVE_POLICY: SecurityPolicy = {
+  defaultAction: 'ALLOW',
+  modules: {},
+};
+
+export function loadCloudPolicyCache(): CloudPolicyCache | null {
+  try {
+    const raw = readFileSync(getDataPath('policies.json'), 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    const record = parsed as Record<string, unknown>;
+    return {
+      shell_rules: Array.isArray(record['shell_rules']) ? (record['shell_rules'] as ShellRule[]) : [],
+      mcp_rules: Array.isArray(record['mcp_rules']) ? (record['mcp_rules'] as McpRule[]) : [],
+      updated_at: typeof record['updated_at'] === 'string' ? record['updated_at'] : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function resolveRuntimePolicy(localPolicy: SecurityPolicy): RuntimePolicyResolution {
+  const cloudPolicy = loadCloudPolicyCache();
+  if (!cloudPolicy) {
+    return {
+      policy: localPolicy,
+      source: 'local',
+      cloudPolicy: null,
+    };
+  }
+
+  return {
+    policy: CLOUD_AUTHORITATIVE_POLICY,
+    source: 'cloud',
+    cloudPolicy,
+  };
+}
+
+export function getCloudAuthoritativeRuntimePolicy(): RuntimePolicyResolution | null {
+  const cloudPolicy = loadCloudPolicyCache();
+  if (!cloudPolicy) {
+    return null;
+  }
+
+  return {
+    policy: CLOUD_AUTHORITATIVE_POLICY,
+    source: 'cloud',
+    cloudPolicy,
+  };
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -19,6 +19,7 @@ import { Interceptor } from '../core/Interceptor';
 import { PolicyStore } from '../storage/PolicyStore';
 import { logger } from '../core/Logger';
 import { createToolCallHook } from './tool-interceptor';
+import { getCloudAuthoritativeRuntimePolicy } from './cloud-policy';
 import { channelContextStore } from './ChannelContextStore';
 import { initNotifier, sendApprovalNotification, type FallbackChannel } from './oob-notifier';
 import { createApproveCommand, createDenyCommand } from './approval-commands';
@@ -179,13 +180,20 @@ export default {
     logger.info('Reins plugin loading...');
 
     try {
-      const policy = PolicyStore.loadSync();
+      const runtimePolicy =
+        getCloudAuthoritativeRuntimePolicy() ||
+        {
+          policy: PolicyStore.loadSync(),
+          source: 'local' as const,
+          cloudPolicy: null,
+        };
       logger.info('Security policy loaded', {
-        defaultAction: policy.defaultAction,
-        moduleCount: Object.keys(policy.modules).length,
+        source: runtimePolicy.source,
+        defaultAction: runtimePolicy.policy.defaultAction,
+        moduleCount: Object.keys(runtimePolicy.policy.modules).length,
       });
 
-      const interceptor = new Interceptor(policy);
+      const interceptor = new Interceptor(runtimePolicy.policy);
 
       // -------------------------------------------------------------------
       // OOB notifier: initialise with runtime send functions + gateway config

--- a/src/plugin/tool-interceptor.ts
+++ b/src/plugin/tool-interceptor.ts
@@ -11,6 +11,11 @@ import { MemoryRiskForecaster, MemoryRiskAssessment } from '../core/MemoryRiskFo
 import { trustRateLimiter } from '../core/TrustRateLimiter';
 import { InterventionMetadata } from '../types';
 import { BrowserSessionStore } from '../storage/BrowserSessionStore';
+import { loadCloudPolicyCache } from './cloud-policy';
+import {
+  evaluateCloudMcpRule,
+  evaluateCloudShellRule,
+} from './cloud-policy-evaluator';
 import {
   classifyDestructiveAction,
   DestructiveClassification,
@@ -120,6 +125,106 @@ export function createToolCallHook(
 
     let params = event.params;
     let shouldReturnParams = false;
+    const cloudPolicy = loadCloudPolicyCache();
+
+    if (
+      cloudPolicy &&
+      moduleName === 'Shell' &&
+      ['bash', 'exec'].includes(methodName)
+    ) {
+      const command = typeof params.command === 'string' ? params.command : '';
+      const matchedRule = evaluateCloudShellRule(command, cloudPolicy);
+
+      if (matchedRule?.action === 'BLOCK') {
+        const reason =
+          `Reins Cloud policy blocked shell command. ` +
+          `${matchedRule.description || 'No description provided.'} ` +
+          `[rule: ${matchedRule.rule}; severity: ${matchedRule.severity || 'unknown'}]`;
+        await DecisionLog.append({
+          timestamp: new Date().toISOString(),
+          module: moduleName,
+          method: methodName,
+          args: [params],
+          decision: 'BLOCKED',
+          decisionTime: 0,
+          reason,
+          eventType: 'tool_blocked',
+          tool: toolName,
+        });
+        return { block: true, blockReason: reason };
+      }
+
+      if (matchedRule?.action === 'WARN') {
+        logger.warn('Reins Cloud shell rule matched with WARN action', {
+          toolName,
+          command,
+          rule: matchedRule.rule,
+          severity: matchedRule.severity,
+        });
+      }
+
+      await DecisionLog.append({
+        timestamp: new Date().toISOString(),
+        module: moduleName,
+        method: methodName,
+        args: [params],
+        decision: 'ALLOWED',
+        decisionTime: 0,
+        reason: matchedRule
+          ? 'allowed by Reins Cloud shell policy cache'
+          : 'allowed by Reins Cloud shell policy cache (no matching block rule)',
+        eventType: 'tool_executed',
+        tool: toolName,
+      });
+      return shouldReturnParams ? { params } : {};
+    }
+
+    // Checks if rule matches one of the MCP tool names (if not, matchedRule will be null and execution continues)
+    if (cloudPolicy) {
+      const matchedRule = evaluateCloudMcpRule(toolName, cloudPolicy);
+
+      if (matchedRule?.action === 'BLOCK') {
+        const reason =
+          `Reins Cloud policy blocked MCP tool. ` +
+          `${matchedRule.description || 'No description provided.'} ` +
+          `[rule: ${matchedRule.rule}; severity: ${matchedRule.severity || 'unknown'}]`;
+        await DecisionLog.append({
+          timestamp: new Date().toISOString(),
+          module: moduleName,
+          method: methodName,
+          args: [params],
+          decision: 'BLOCKED',
+          decisionTime: 0,
+          reason,
+          eventType: 'tool_blocked',
+          tool: toolName,
+        });
+        return { block: true, blockReason: reason };
+      }
+
+      if (matchedRule?.action === 'WARN') {
+        logger.warn('Reins Cloud MCP rule matched with WARN action', {
+          toolName,
+          rule: matchedRule.rule,
+          severity: matchedRule.severity,
+        });
+      }
+
+      if (matchedRule) {
+        await DecisionLog.append({
+          timestamp: new Date().toISOString(),
+          module: moduleName,
+          method: methodName,
+          args: [params],
+          decision: 'ALLOWED',
+          decisionTime: 0,
+          reason: 'allowed by Reins Cloud MCP policy cache',
+          eventType: 'tool_executed',
+          tool: toolName,
+        });
+        return shouldReturnParams ? { params } : {};
+      }
+    }
 
     // Persistent browser-session management.
     if (moduleName === 'Browser') {

--- a/src/storage/WatchtowerConfig.ts
+++ b/src/storage/WatchtowerConfig.ts
@@ -14,6 +14,7 @@ export interface WatchtowerSettings {
   org_id?: string;
   team_id?: string;
   device_id?: string;
+  bootstrapToken?: string;
 }
 
 interface ReinsConfigFile {
@@ -27,6 +28,11 @@ export interface WatchtowerCredentials {
   dashboardUrl?: string;
   email?: string;
   source: 'config' | 'env';
+}
+
+export interface WatchtowerBootstrap {
+  token: string;
+  baseUrl: string;
 }
 
 function getWatchtowerConfigFilePath(): string {
@@ -106,6 +112,29 @@ export async function resolveWatchtowerCredentials(): Promise<WatchtowerCredenti
     email: saved?.email?.trim(),
     source: 'config',
   };
+}
+
+export async function resolveWatchtowerBootstrap(): Promise<WatchtowerBootstrap | null> {
+  const baseUrl =
+    process.env.REINS_CLOUD_BASE_URL?.trim()
+    || process.env.REINS_WATCHTOWER_BASE_URL?.trim()
+    || process.env.CLAWREINS_WATCHTOWER_BASE_URL?.trim()
+    || DEFAULT_WATCHTOWER_BASE_URL;
+
+  const saved = await loadWatchtowerSettings();
+  const token =
+    process.env.REINS_ENROLLMENT_TOKEN?.trim()
+    || process.env.REINS_BOOTSTRAP_TOKEN?.trim()
+    || process.env.CLAWREINS_ENROLLMENT_TOKEN?.trim()
+    || process.env.CLAWREINS_BOOTSTRAP_TOKEN?.trim()
+    || saved?.bootstrapToken?.trim()
+    || '';
+
+  if (!token) {
+    return null;
+  }
+
+  return { token, baseUrl };
 }
 
 export function getWatchtowerConfigPath(): string {

--- a/test/bootstrap-client.test.mjs
+++ b/test/bootstrap-client.test.mjs
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import https from 'node:https';
+import { Readable } from 'node:stream';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const { redeemReinsBootstrap } = require('../dist/lib/watchtower-client.js');
+const {
+  getWatchtowerConfigPath,
+  resolveWatchtowerBootstrap,
+  saveWatchtowerSettings,
+} = require('../dist/storage/WatchtowerConfig.js');
+
+test('resolveWatchtowerBootstrap reads token from environment', async () => {
+  const originalToken = process.env.REINS_ENROLLMENT_TOKEN;
+  const originalBaseUrl = process.env.REINS_CLOUD_BASE_URL;
+  try {
+    process.env.REINS_ENROLLMENT_TOKEN = 'bootstrap_123';
+    process.env.REINS_CLOUD_BASE_URL = 'https://app-staging.pegasi.ai';
+    const bootstrap = await resolveWatchtowerBootstrap();
+    assert.deepEqual(bootstrap, {
+      token: 'bootstrap_123',
+      baseUrl: 'https://app-staging.pegasi.ai',
+    });
+  } finally {
+    if (originalToken === undefined) {
+      delete process.env.REINS_ENROLLMENT_TOKEN;
+    } else {
+      process.env.REINS_ENROLLMENT_TOKEN = originalToken;
+    }
+    if (originalBaseUrl === undefined) {
+      delete process.env.REINS_CLOUD_BASE_URL;
+    } else {
+      process.env.REINS_CLOUD_BASE_URL = originalBaseUrl;
+    }
+  }
+});
+
+test('redeemReinsBootstrap exchanges a token for an org-scoped api key', async () => {
+  const originalRequest = https.request;
+  const captured = {};
+
+  https.request = (options, callback) => {
+    Object.assign(captured, options);
+    const response = new Readable({ read() {} });
+    response.statusCode = 200;
+    process.nextTick(() => {
+      callback(response);
+      response.push(JSON.stringify({
+        api_key: 'cr_test_key',
+        organization: { id: 'org_alpha', name: 'Alpha Org' },
+      }));
+      response.push(null);
+    });
+
+    return {
+      on() { return this; },
+      write() {},
+      end() {},
+      destroy() {},
+    };
+  };
+
+  try {
+    const result = await redeemReinsBootstrap('bootstrap_123', 'https://app-staging.pegasi.ai');
+    assert.equal(result.api_key, 'cr_test_key');
+    assert.deepEqual(result.organization, { id: 'org_alpha', name: 'Alpha Org' });
+    assert.match(String(captured.path), /\/api\/auth\/reins-bootstrap\/redeem$/);
+  } finally {
+    https.request = originalRequest;
+  }
+});
+
+test('saveWatchtowerSettings writes bootstrapToken into config', async () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'reins-bootstrap-'));
+  const originalXdg = process.env.XDG_CONFIG_HOME;
+  try {
+    process.env.XDG_CONFIG_HOME = tempRoot;
+    await saveWatchtowerSettings({
+      bootstrapToken: 'bootstrap_456',
+      baseUrl: 'https://app-staging.pegasi.ai',
+    });
+    const config = JSON.parse(readFileSync(getWatchtowerConfigPath(), 'utf8'));
+    assert.equal(config.watchtower.bootstrapToken, 'bootstrap_456');
+    assert.equal(config.watchtower.baseUrl, 'https://app-staging.pegasi.ai');
+  } finally {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdg;
+    }
+  }
+});

--- a/test/policy.test.mjs
+++ b/test/policy.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
-import { mkdtempSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 
 const openclawHome = mkdtempSync(path.join(os.tmpdir(), 'reins-policy-tests-'));
 mkdirSync(openclawHome, { recursive: true });
@@ -14,6 +14,7 @@ process.env.REINS_DESTRUCTIVE_GATING = 'off';
 const require = createRequire(import.meta.url);
 const { Interceptor } = require('../dist/core/Interceptor.js');
 const { createToolCallHook } = require('../dist/plugin/tool-interceptor.js');
+const { resolveRuntimePolicy } = require('../dist/plugin/cloud-policy.js');
 
 // Temp dirs used as stand-ins for real paths — no real directories assumed
 const allowedDir = mkdtempSync(path.join(os.tmpdir(), 'reins-allowed-'));
@@ -23,6 +24,16 @@ const allowedFile = path.join(allowedDir, 'output.txt');
 const outsideFile = path.join(outsideDir, 'other.txt');
 const secretsFile = path.join(secretsDir, 'keys.json');
 const nestedFile = path.join(allowedDir, 'subdir', 'readme.md');
+
+function writeCloudPolicies(payload) {
+  const reinsDir = path.join(openclawHome, 'reins');
+  mkdirSync(reinsDir, { recursive: true });
+  writeFileSync(path.join(reinsDir, 'policies.json'), JSON.stringify(payload, null, 2));
+}
+
+function clearCloudPolicies() {
+  rmSync(path.join(openclawHome, 'reins', 'policies.json'), { force: true });
+}
 
 // ---------------------------------------------------------------------------
 // defaultAction
@@ -56,6 +67,60 @@ test('defaultAction ALLOW passes unmapped tools', async () => {
   );
 
   assert.notEqual(result.block, true);
+});
+
+test('cloud policy becomes the authoritative runtime policy when policies.json exists', () => {
+  writeCloudPolicies({
+    shell_rules: [],
+    mcp_rules: [],
+    updated_at: new Date().toISOString(),
+  });
+
+  const localPolicy = {
+    defaultAction: 'DENY',
+    modules: {
+      Shell: {
+        exec: { action: 'DENY', description: 'local deny should be ignored' },
+      },
+    },
+  };
+
+  const runtime = resolveRuntimePolicy(localPolicy);
+  assert.equal(runtime.source, 'cloud');
+  assert.equal(runtime.policy.defaultAction, 'ALLOW');
+  assert.deepEqual(runtime.policy.modules, {});
+
+  clearCloudPolicies();
+});
+
+test('cloud shell cache overrides local shell policy in OpenClaw runtime', async () => {
+  writeCloudPolicies({
+    shell_rules: [],
+    mcp_rules: [],
+    updated_at: new Date().toISOString(),
+  });
+
+  const interceptor = new Interceptor(
+    {
+      defaultAction: 'DENY',
+      modules: {
+        Shell: {
+          exec: { action: 'DENY', description: 'local deny should be ignored' },
+        },
+      },
+    },
+    false
+  );
+  const hook = createToolCallHook(interceptor);
+
+  const result = await hook(
+    { toolName: 'exec', params: { command: 'echo avocado' } },
+    { toolName: 'exec', sessionKey: 'policy:cloud-shell-authoritative' }
+  );
+
+  assert.notEqual(result.block, true);
+
+  clearCloudPolicies();
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Dependent on PR #73. 

These changes make Reins usable as a Claude Enterprise plugin. Onboarding works using a bootstrap token, which is created by Reins Cloud and used by the admin while updating the Claude-managed settings. This token is passed into each team member's Reins install, and it is used to authorize enrollment into their Reins Cloud organization. Hooks are explicitly configured so that Claude can run a hook wrapper pre- and post-tool call, which get resolved to the real hook implementations in Reins.